### PR TITLE
win32 support

### DIFF
--- a/gcov7-json.cmd
+++ b/gcov7-json.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+
+set "mydir=%~dp0"
+python3 "%mydir%\gcov7-json.py" %*

--- a/gcov7-json.py
+++ b/gcov7-json.py
@@ -77,10 +77,13 @@ def main():
     file_list = [ os.path.realpath(a) for a in file_list ]
     file_para = " ".join(file_list)
     with TemporaryDirectory() as dirname:
-        f = os.popen("cd {} && gcov -b -c -x -i -l {}".format(dirname, file_para))
+        f = os.popen("pushd {} && gcov -b -c -x -i -l {}".format(dirname, file_para))
         result = f.readlines()
         #print(result)
-        f = os.popen("cat {}/*.gcov".format(dirname, file_para))
+        if os.name == "nt":
+            f = os.popen("pushd {} && type *.gcov".format(dirname, file_para))
+        if else:
+            f = os.popen("pushd {} && cat *.gcov".format(dirname, file_para))
         result = f.readlines()
         #print(result)
         resolv(result)


### PR DESCRIPTION
* gcov7-json.cmd: add cmd wrapper to execute the script
* gcov7-json.py:
   * switch to temp directory before `cat`, reducing command line length
   * prefer `pushd` over `cd` as this also changes the harddrive, if needed
   * adjust system call to get data depending on `os.name == "nt"`
